### PR TITLE
fix: add puma_worker_killer to prevent OOM kills

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem "sqlite3", ">= 2.1"
 gem "pg", "~> 1.5"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 8"
+# Automatically restart Puma workers that exceed memory thresholds [https://github.com/zombocom/puma_worker_killer]
+gem "puma_worker_killer"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
       raabro (~> 1.4)
     gemoji (4.1.0)
     geokit (1.14.0)
+    get_process_mem (1.0.0)
+      bigdecimal (>= 2.0)
+      ffi (~> 1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     google-protobuf (4.34.1)
@@ -407,6 +410,10 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.1)
       nio4r (~> 2.0)
+    puma_worker_killer (1.0.0)
+      bigdecimal (>= 2.0)
+      get_process_mem (>= 0.2)
+      puma (>= 2.7)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -708,6 +715,7 @@ DEPENDENCIES
   pg (~> 1.5)
   propshaft
   puma (~> 8)
+  puma_worker_killer
   rack-attack
   rails (~> 8.1.1)
   rails-controller-testing
@@ -737,4 +745,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-  4.0.6
+   4.0.6

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,6 +27,10 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
+workers ENV.fetch("WEB_CONCURRENCY", 0).to_i
+
+preload_app!
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 
@@ -35,6 +39,19 @@ plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+
+before_fork do
+  require "puma_worker_killer"
+
+  PumaWorkerKiller.config do |config|
+    config.ram = ENV.fetch("PUMA_WORKER_KILLER_RAM_MB", 1024).to_i
+    config.frequency = 20
+    config.percent_usage = 0.90
+    config.rolling_restart_frequency = 12 * 3600
+    config.reaper_status_logs = false
+  end
+  PumaWorkerKiller.start
+end
 
 plugin :honeybadger
 


### PR DESCRIPTION
## Problem

Running on a memory-constrained NAS (2 GB container limit), the Puma process and its SolidQueue workers gradually accumulate memory over time, eventually causing OOM kills. The container has been OOM-killed 4 times recently.

Investigation showed:
- Ruby 3.4 with YJIT enabled contributes significant per-process memory (now disabled via `RUBY_YJIT_ENABLE=0` in compose)
- Even with `WEB_CONCURRENCY=0` (single Puma process), memory grows unbounded over hours/days
- SolidQueue runs 4 processes in-process (supervisor, dispatcher, worker, scheduler), all sharing the 2 GB limit
- There is no mechanism to recycle bloated workers

## Solution

- Add `puma_worker_killer` gem to automatically restart Puma workers when combined memory exceeds a configurable threshold (`PUMA_WORKER_KILLER_RAM_MB`, default 1024 MB)
- Enable cluster mode via `workers ENV.fetch("WEB_CONCURRENCY", 0).to_i` so workers can be recycled independently of the master
- Add `preload_app!` for copy-on-write memory savings across workers
- Configure a defensive rolling restart every 12 hours
- `before_fork` placement is safe with the SolidQueue plugin — it forks from the master via `after_booted`, not from workers

## NAS compose changes (separate repo)

Will update `WEB_CONCURRENCY` from `0` → `2` and add `PUMA_WORKER_KILLER_RAM_MB: 1100` after this is released.