### PR TITLE
chore: add derailed_benchmarks for memory profiling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "htmlcompressor"
 # See https://github.com/mperham/connection_pool/issues/210
 gem "connection_pool", "< 3"
 
+# Memory profiling and leak detection [https://github.com/zombocom/derailed_benchmarks]
+gem "derailed_benchmarks", require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
     benchmark (0.5.0)
+    benchmark-ips (2.14.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.1)
@@ -123,6 +124,24 @@ GEM
     debugbar (0.4.3)
       actioncable
       rails
+    derailed_benchmarks (2.2.1)
+      base64
+      benchmark-ips (~> 2)
+      bigdecimal
+      drb
+      get_process_mem
+      heapy (~> 0)
+      logger
+      memory_profiler (>= 0, < 2)
+      mini_histogram (>= 0.3.0)
+      mutex_m
+      ostruct
+      rack (>= 1)
+      rack-test
+      rake (> 10, < 14)
+      ruby-statistics (>= 4.0.1)
+      ruby2_keywords
+      thor (>= 0.19, < 2)
     diff-lcs (1.6.2)
     docile (1.4.1)
     dockerfile-rails (1.7.10)
@@ -209,6 +228,8 @@ GEM
       activesupport (>= 3.0)
       graphql (>= 1.13.0)
     hashdiff (1.2.1)
+    heapy (0.2.0)
+      thor
     honeybadger (6.5.5)
       logger
       ostruct
@@ -272,7 +293,9 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.3)
+    memory_profiler (1.1.0)
     metrics (0.15.0)
+    mini_histogram (0.3.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (6.0.5)
@@ -289,6 +312,7 @@ GEM
       stimulus-rails
       turbo-rails
     msgpack (1.8.0)
+    mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.4)
@@ -528,6 +552,8 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-statistics (4.1.1)
+    ruby2_keywords (0.0.5)
     rubyzip (3.2.2)
     sass-embedded (1.99.0)
       google-protobuf (~> 4.31)
@@ -685,6 +711,7 @@ DEPENDENCIES
   dartsass-rails (~> 0.5.1)
   debug
   debugbar
+  derailed_benchmarks
   dockerfile-rails (>= 1.6)
   factory_bot (~> 6.5)
   factory_bot_rails (~> 6.4)

--- a/script/profile_jobs_memory.rb
+++ b/script/profile_jobs_memory.rb
@@ -1,0 +1,109 @@
+require "get_process_mem"
+require "objspace"
+
+ITERATIONS = (ENV.fetch("PROFILE_ITERATIONS", 20)).to_i
+JOBS = [
+  -> { ScheduleCacheRefreshJob.perform_now },
+  -> { SendMetricsJob.perform_now },
+  -> { MergeRequestsFetchJob.perform_now(User.first&.username, :open) },
+].freeze
+
+def snapshot_label(i)
+  i.zero? ? "baseline" : "iteration #{i}"
+end
+
+def rss_mb
+  GetProcessMem.new.mb
+end
+
+def object_counts
+  counts = Hash.new(0)
+  ObjectSpace.each_object { |o| counts[o.class] += 1 }
+  counts.sort_by { |_, v| -v }.first(20).to_h
+end
+
+def gc_stats
+  s = GC.stat
+  { count: s[:count], heap_live_slots: s[:heap_live_slots], heap_free_slots: s[:heap_free_slots] }
+end
+
+def print_separator
+  puts "-" * 70
+end
+
+def print_snapshot(label, rss, counts, gc)
+  puts "\n=== #{label} ==="
+  puts "RSS: #{rss.round(1)} MB"
+  puts "GC:  count=#{gc[:count]}  live_slots=#{gc[:heap_live_slots]}  free_slots=#{gc[:heap_free_slots]}"
+  puts "Top object counts:"
+  counts.each { |klass, n| puts "  #{klass.name.ljust(50)} #{n}" }
+end
+
+def compact_and_report(label)
+  before = GC.stat[:heap_live_slots]
+  GC.compact
+  after = GC.stat[:heap_live_slots]
+  puts "  [#{label}] GC.compact: live_slots #{before} -> #{after} (freed #{before - after})"
+end
+
+print_separator
+puts "SolidQueue job memory profiler"
+puts "Iterations: #{ITERATIONS}"
+puts "PID: #{Process.pid}  Ruby: #{RUBY_VERSION}"
+print_separator
+
+GC.start(full_mark: true, immediate_sweep: true)
+compact_and_report("baseline")
+
+baseline_rss    = rss_mb
+baseline_counts = object_counts
+baseline_gc     = gc_stats
+print_snapshot("baseline", baseline_rss, baseline_counts, baseline_gc)
+
+rss_history = [baseline_rss]
+
+ITERATIONS.times do |i|
+  JOBS.each do |job|
+    begin
+      job.call
+    rescue => e
+      puts "  [iteration #{i + 1}] job raised #{e.class}: #{e.message.lines.first.chomp}"
+    end
+  end
+
+  GC.start(full_mark: true, immediate_sweep: true)
+  current_rss    = rss_mb
+  current_counts = object_counts
+  current_gc     = gc_stats
+  rss_history << current_rss
+
+  growth = current_rss - baseline_rss
+  step   = current_rss - rss_history[-2]
+
+  puts "\n=== iteration #{i + 1}/#{ITERATIONS} ==="
+  puts "RSS: #{current_rss.round(1)} MB  (#{growth >= 0 ? "+" : ""}#{growth.round(1)} MB from baseline, #{step >= 0 ? "+" : ""}#{step.round(1)} MB from last)"
+  puts "GC:  count=#{current_gc[:count]}  live_slots=#{current_gc[:heap_live_slots]}  free_slots=#{current_gc[:heap_free_slots]}"
+
+  new_objects = current_counts.filter_map do |klass, n|
+    diff = n - (baseline_counts[klass] || 0)
+    [klass, n, diff] if diff > 100
+  end.sort_by { |_, _, d| -d }.first(15)
+
+  if new_objects.any?
+    puts "Object growth vs baseline (>100 new):"
+    new_objects.each { |klass, n, diff| puts "  #{klass.name.ljust(50)} #{n}  (+#{diff})" }
+  end
+end
+
+print_separator
+puts "\nSummary"
+puts "RSS history (MB): #{rss_history.map { |r| r.round(1) }.join(" -> ")}"
+total_growth = rss_history.last - rss_history.first
+puts "Total growth: #{total_growth >= 0 ? "+" : ""}#{total_growth.round(1)} MB over #{ITERATIONS} iterations"
+puts "Average growth per iteration: #{(total_growth / ITERATIONS).round(2)} MB"
+
+compact_and_report("final")
+final_rss = rss_mb
+puts "RSS after final GC.compact: #{final_rss.round(1)} MB"
+puts "Retained (non-reclaimable) growth: #{(final_rss - baseline_rss).round(1)} MB"
+print_separator


### PR DESCRIPTION
## Context

The NAS-hosted instance has been experiencing repeated OOM kills due to gradual memory growth in SolidQueue worker processes. Adding `derailed_benchmarks` to the development group to help identify the leak source (suspected: `MergeRequestsFetchJob`, `ScheduleCacheRefreshJob`, or Honeybadger Insights buffering).

## Usage

```sh
bundle exec derailed bundle:mem
bundle exec derailed exec perf:mem_over_time
```