### PR TITLE
fix: correct rubocop violations in profile_jobs_memory.rb

### DIFF
--- a/script/profile_jobs_memory.rb
+++ b/script/profile_jobs_memory.rb
@@ -1,16 +1,12 @@
 require "get_process_mem"
 require "objspace"
 
-ITERATIONS = (ENV.fetch("PROFILE_ITERATIONS", 20)).to_i
+ITERATIONS = ENV.fetch("PROFILE_ITERATIONS", 20).to_i
 JOBS = [
   -> { ScheduleCacheRefreshJob.perform_now },
   -> { SendMetricsJob.perform_now },
-  -> { MergeRequestsFetchJob.perform_now(User.first&.username, :open) },
+  -> { MergeRequestsFetchJob.perform_now(User.first&.username, :open) }
 ].freeze
-
-def snapshot_label(i)
-  i.zero? ? "baseline" : "iteration #{i}"
-end
 
 def rss_mb
   GetProcessMem.new.mb
@@ -24,7 +20,7 @@ end
 
 def gc_stats
   s = GC.stat
-  { count: s[:count], heap_live_slots: s[:heap_live_slots], heap_free_slots: s[:heap_free_slots] }
+  {count: s[:count], heap_live_slots: s[:heap_live_slots], heap_free_slots: s[:heap_free_slots]}
 end
 
 def print_separator
@@ -55,33 +51,33 @@ print_separator
 GC.start(full_mark: true, immediate_sweep: true)
 compact_and_report("baseline")
 
-baseline_rss    = rss_mb
+baseline_rss = rss_mb
 baseline_counts = object_counts
-baseline_gc     = gc_stats
+baseline_gc = gc_stats
 print_snapshot("baseline", baseline_rss, baseline_counts, baseline_gc)
 
 rss_history = [baseline_rss]
 
 ITERATIONS.times do |i|
   JOBS.each do |job|
-    begin
-      job.call
-    rescue => e
-      puts "  [iteration #{i + 1}] job raised #{e.class}: #{e.message.lines.first.chomp}"
-    end
+    job.call
+  rescue => e
+    puts "  [iteration #{i + 1}] job raised #{e.class}: #{e.message.lines.first.chomp}"
   end
 
   GC.start(full_mark: true, immediate_sweep: true)
-  current_rss    = rss_mb
+  current_rss = rss_mb
   current_counts = object_counts
-  current_gc     = gc_stats
+  current_gc = gc_stats
   rss_history << current_rss
 
   growth = current_rss - baseline_rss
-  step   = current_rss - rss_history[-2]
+  step = current_rss - rss_history[-2]
 
   puts "\n=== iteration #{i + 1}/#{ITERATIONS} ==="
-  puts "RSS: #{current_rss.round(1)} MB  (#{growth >= 0 ? "+" : ""}#{growth.round(1)} MB from baseline, #{step >= 0 ? "+" : ""}#{step.round(1)} MB from last)"
+  growth_sign = growth >= 0 ? "+" : ""
+  step_sign = step >= 0 ? "+" : ""
+  puts "RSS: #{current_rss.round(1)} MB  (#{growth_sign}#{growth.round(1)} MB from baseline, #{step_sign}#{step.round(1)} MB from last)"
   puts "GC:  count=#{current_gc[:count]}  live_slots=#{current_gc[:heap_live_slots]}  free_slots=#{current_gc[:heap_free_slots]}"
 
   new_objects = current_counts.filter_map do |klass, n|
@@ -99,7 +95,8 @@ print_separator
 puts "\nSummary"
 puts "RSS history (MB): #{rss_history.map { |r| r.round(1) }.join(" -> ")}"
 total_growth = rss_history.last - rss_history.first
-puts "Total growth: #{total_growth >= 0 ? "+" : ""}#{total_growth.round(1)} MB over #{ITERATIONS} iterations"
+total_sign = total_growth >= 0 ? "+" : ""
+puts "Total growth: #{total_sign}#{total_growth.round(1)} MB over #{ITERATIONS} iterations"
 puts "Average growth per iteration: #{(total_growth / ITERATIONS).round(2)} MB"
 
 compact_and_report("final")


### PR DESCRIPTION
Fixes linting errors introduced in #470:
- Remove redundant parentheses around `ENV.fetch`
- Remove trailing comma in array literal
- Fix hash brace spacing
- Remove extra spacing in assignments
- Remove redundant `begin` block in rescue
- Extract sign ternaries to variables to avoid `Style/EmptyStringInsideInterpolation`