### PR TITLE
fix: satisfy Style/TernaryParentheses in profile_jobs_memory.rb

### DIFF
--- a/script/profile_jobs_memory.rb
+++ b/script/profile_jobs_memory.rb
@@ -75,8 +75,8 @@ ITERATIONS.times do |i|
   step = current_rss - rss_history[-2]
 
   puts "\n=== iteration #{i + 1}/#{ITERATIONS} ==="
-  growth_sign = growth >= 0 ? "+" : ""
-  step_sign = step >= 0 ? "+" : ""
+  growth_sign = (growth >= 0) ? "+" : ""
+  step_sign = (step >= 0) ? "+" : ""
   puts "RSS: #{current_rss.round(1)} MB  (#{growth_sign}#{growth.round(1)} MB from baseline, #{step_sign}#{step.round(1)} MB from last)"
   puts "GC:  count=#{current_gc[:count]}  live_slots=#{current_gc[:heap_live_slots]}  free_slots=#{current_gc[:heap_free_slots]}"
 
@@ -95,7 +95,7 @@ print_separator
 puts "\nSummary"
 puts "RSS history (MB): #{rss_history.map { |r| r.round(1) }.join(" -> ")}"
 total_growth = rss_history.last - rss_history.first
-total_sign = total_growth >= 0 ? "+" : ""
+total_sign = (total_growth >= 0) ? "+" : ""
 puts "Total growth: #{total_sign}#{total_growth.round(1)} MB over #{ITERATIONS} iterations"
 puts "Average growth per iteration: #{(total_growth / ITERATIONS).round(2)} MB"
 


### PR DESCRIPTION
## Summary

- Wraps the three comparison-based ternary conditions in `script/profile_jobs_memory.rb` with parentheses to satisfy StandardRB's `Style/TernaryParentheses` cop.
- This was introduced by #470 and not caught by the CI lint gate before #473 was merged, leaving `main` with a permanently red lint check.
- Unblocks the Renovate lock-file maintenance PR #474 (and any future PRs) from passing lint.