### PR TITLE
fix: pin Renovate's Yarn to match project's packageManager

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -107,6 +107,9 @@
       "depNameTemplate": "node"
     }
   ],
+  "constraints": {
+    "yarn": "4.12.0"
+  },
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "platformAutomerge": true


### PR DESCRIPTION
## Summary

- Adds `"constraints": { "yarn": "4.12.0" }` to `.renovaterc.json` so Renovate uses the same Yarn version as the project's `packageManager` pin when regenerating `yarn.lock`.
- Without this, Renovate was using a newer Yarn (≥ 4.10.0) that writes `__metadata.version: 9` into the lockfile, while CI's Docker image resolved an older Yarn writing `version: 8` — causing `yarn install --immutable` to fail with `YN0028`.
- After merging, the next Renovate lock-file maintenance run will regenerate `yarn.lock` with the correct metadata version, unblocking PR #474 (or its successor).