### PR TITLE
fix: bump Yarn to 4.14.1 to align lockfile version with Renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -107,9 +107,6 @@
       "depNameTemplate": "node"
     }
   ],
-  "constraints": {
-    "yarn": "4.12.0"
-  },
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "platformAutomerge": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "type": "module",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.1.0",
     "@hotwired/stimulus": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@esbuild/aix-ppc64@npm:0.27.2":


### PR DESCRIPTION
## Summary

- Bumps `packageManager` in `package.json` from `yarn@4.12.0` to `yarn@4.14.1`.
- Regenerates `yarn.lock` so `__metadata.version` becomes `9` (matching what Renovate now produces).
- Removes the stale `constraints.yarn: 4.12.0` block from `.renovaterc.json`, which Renovate's hosted runner was not honoring anyway.

## Why

The weekly `renovate/lock-file-maintenance` PRs (e.g. #474, #484) keep failing CI on `yarn install --immutable` with `YN0028: The lockfile would have been modified by this install`. The diff Yarn produces is always the same `version: 9` → `version: 8` lockfile metadata flip.

Root cause: Yarn `4.14.0` bumped `LOCKFILE_VERSION` from `8` to `9` (verified against upstream `yarnpkg/berry` source at tags `@yarnpkg/cli/4.13.0` and `@yarnpkg/cli/4.14.0`). Renovate's hosted runner regenerates the lockfile with a Yarn ≥ 4.14.0, while CI/Docker resolve `yarn@4.12.0` via Corepack from `packageManager` and write `version: 8`. The PR #476 attempt to fix this with `constraints.yarn: 4.12.0` had no effect because Renovate didn't honor it.

Aligning the project's pinned Yarn with the one Renovate uses removes the skew entirely, without depending on Renovate's `constraints` enforcement.

## Verification

Locally, with Yarn 4.14.1 via Corepack:

- `yarn install` — clean install (172 packages, project migrated by `YN0087`)
- `yarn install --immutable` — passes (this is what CI runs)
- `yarn lint` — passes
- `yarn format:check` — passes
- `yarn typecheck` — pre-existing failure on `main` (missing `@types/bootstrap`), unchanged by this PR and not part of CI

Lockfile `__metadata.version` is now `9` on both ends, so future lock-file-maintenance PRs should pass CI as-is.